### PR TITLE
Add an option to map L2/R2 to front touchpad

### DIFF
--- a/companion/main.cpp
+++ b/companion/main.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 #define CONFIG_FILE_PATH "ux0:data/gtasa/config.txt"
-#define NUM_OPTIONS 16
+#define NUM_OPTIONS 17
 
 int _newlib_heap_size_user = 192 * 1024 * 1024;
 
@@ -32,6 +32,7 @@ char *AntiAliasingName[ANTI_ALIASING_NUM] = {
 
 int touch_x_margin = 100;
 bool fix_heli_plane_camera = true;
+bool front_touch_triggers = false;
 bool fix_skin_weights = true;
 bool fix_map_bottleneck = true;
 bool use_shader_cache = true;
@@ -57,6 +58,7 @@ void loadConfig() {
     while (EOF != fscanf(config, "%[^ ] %d\n", buffer, &value)) {
       if (strcmp("touch_x_margin", buffer) == 0) touch_x_margin = value;
       else if (strcmp("fix_heli_plane_camera", buffer) == 0) fix_heli_plane_camera = (bool)value;
+      else if (strcmp("front_touch_triggers", buffer) == 0) front_touch_triggers = (bool)value;
       else if (strcmp("ignore_mobile_stuff", buffer) == 0) mobile_stuff = value ? false : true;
 
       else if (strcmp("fix_skin_weights", buffer) == 0) fix_skin_weights = (bool)value;
@@ -85,6 +87,7 @@ void saveConfig() {
   if (config) {
     fprintf(config, "%s %d\n", "touch_x_margin", touch_x_margin);
     fprintf(config, "%s %d\n", "fix_heli_plane_camera", (int)fix_heli_plane_camera);
+    fprintf(config, "%s %d\n", "front_touch_triggers", (int)front_touch_triggers);
     fprintf(config, "%s %d\n", "ignore_mobile_stuff", mobile_stuff ? false : true);
 
     fprintf(config, "%s %d\n", "fix_skin_weights", (int)fix_skin_weights);
@@ -110,6 +113,7 @@ void saveConfig() {
 char *options_descs[NUM_OPTIONS] = {
   "Deadzone in pixels to use between inputs on both rearpad and touchscreen.\nThe default value is: 100.", // touch_x_margin
   "Makes it possible to move the camera with the right stick when using a flying vehicle (Planes and helicopters).\nThe default value is: Enabled.", // fix_heli_plane_camera
+  "When enabled, L2/R2 will be mapped to the top of the front touchpad instead of the rear.\nThe default value is: Disabled.", // front_touch_triggers
   "Select the desired post processing effect filter to apply to the 3D rendering.\nThe default value is: PS2.", // skygfx_colorfilter
   "Enables shading effects that resamble the PS2 build.\nThe default value is: Enabled.", // skygfx_ps2_shading
   "Enables corona sun effect that resambles the PS2 build.\nThe default value is: Enabled.", // skygfx_ps2_sun
@@ -129,6 +133,7 @@ char *options_descs[NUM_OPTIONS] = {
 enum {
   OPT_DEADZONE,
   OPT_FLYING_VEHICLES_FIX,
+  OPT_FRONT_TOUCH_TRIGGERS,
   OPT_COLOR_FILTER,
   OPT_PS2_SHADING,
   OPT_PS2_SUN,
@@ -183,6 +188,9 @@ int main(int argc, char *argv[]) {
     ImGui::Text("Flying Vehicles Camera Fix:"); ImGui::SameLine();
     ImGui::Checkbox("##check1", &fix_heli_plane_camera);
     SetDescription(OPT_FLYING_VEHICLES_FIX);
+    ImGui::Text("Front Touchpad L2/R2:"); ImGui::SameLine();
+    ImGui::Checkbox("##check14", &front_touch_triggers); 
+    SetDescription(OPT_FRONT_TOUCH_TRIGGERS);
     ImGui::Separator();
     ImGui::PopStyleVar();
 

--- a/loader/config.c
+++ b/loader/config.c
@@ -25,6 +25,7 @@ int read_config(const char *file) {
   config.enable_bones_optimization = 0;
   config.enable_mvp_optimization = 0;
   config.ignore_mobile_stuff = 1;
+  config.front_touch_triggers = 0;
   config.fix_heli_plane_camera = 1;
   config.fix_skin_weights = 1;
   config.fix_map_bottleneck = 1;
@@ -48,6 +49,7 @@ int read_config(const char *file) {
     CONFIG_VAR(enable_bones_optimization);
     CONFIG_VAR(enable_mvp_optimization);
     CONFIG_VAR(ignore_mobile_stuff);
+    CONFIG_VAR(front_touch_triggers);
     CONFIG_VAR(fix_heli_plane_camera);
     CONFIG_VAR(fix_skin_weights);
     CONFIG_VAR(fix_map_bottleneck);

--- a/loader/config.h
+++ b/loader/config.h
@@ -29,6 +29,7 @@ typedef struct {
   int enable_mvp_optimization;
   int ignore_mobile_stuff;
   int fix_heli_plane_camera;
+  int front_touch_triggers;
   int fix_skin_weights;
   int fix_map_bottleneck;
   int use_shader_cache;

--- a/loader/jni_patch.c
+++ b/loader/jni_patch.c
@@ -183,14 +183,28 @@ float GetGamepadAxis(int port, int axis) {
       }
 
       if (port == 0) {
-        for (int i = 0; i < touch_back.reportNum; i++) {
-          if (touch_back.report[i].y < (panelInfoBack.minAaY + panelInfoBack.maxAaY) / 2) {
-            if (touch_back.report[i].x < (panelInfoBack.minAaX + panelInfoBack.maxAaX) / 2) {
-              if (touch_back.report[i].x >= config.touch_x_margin)
-                if (axis == 4) val = 1.0f;
-            } else {
-              if (touch_back.report[i].x < (panelInfoBack.maxAaX - config.touch_x_margin))
+        if (config.front_touch_triggers) {
+          for (int i = 0; i < touch_front.reportNum; i++) {
+            if (touch_front.report[i].y < (panelInfoFront.minAaY + panelInfoFront.maxAaY) / 2) {
+              if (touch_front.report[i].x < (panelInfoFront.minAaX + panelInfoFront.maxAaX) / 2) {
+                if (touch_front.report[i].x >= config.touch_x_margin)
+                  if (axis == 4) val = 1.0f;
+              } else {
+               if (touch_back.report[i].x < (panelInfoFront.maxAaX - config.touch_x_margin))
                 if (axis == 5) val = 1.0f;
+              }
+            }
+          }
+        } else {
+          for (int i = 0; i < touch_back.reportNum; i++) {
+            if (touch_back.report[i].y < (panelInfoBack.minAaY + panelInfoBack.maxAaY) / 2) {
+              if (touch_back.report[i].x < (panelInfoBack.minAaX + panelInfoBack.maxAaX) / 2) {
+                if (touch_back.report[i].x >= config.touch_x_margin)
+                  if (axis == 4) val = 1.0f;
+              } else {
+                if (touch_back.report[i].x < (panelInfoBack.maxAaX - config.touch_x_margin))
+                  if (axis == 5) val = 1.0f;
+              }
             }
           }
         }


### PR DESCRIPTION
I guess I'm not the only one who can't stand Vita's rearpad, so I added an option to remap triggers to the top of the front touchpad. Earlier today, actual code in loader/jni_patch.c was different, but v1.1 changed a lot so I chose a brute approach.