### PR TITLE
Fix crash on Russian/Japanese language selection

### DIFF
--- a/libc_bridge/nids.yml
+++ b/libc_bridge/nids.yml
@@ -25,6 +25,10 @@ modules:
           sceLibcBridge_fseek: 0xC3A7CDE1
           sceLibcBridge_ftell: 0x41C2AF95
           sceLibcBridge_fwrite: 0x8BCDCC4E
+          sceLibcBridge_fprintf: 0xE0C79764
+          sceLibcBridge_fputc: 0x7E6A6108
+          sceLibcBridge_setjmp: 0x50B326CE
+          sceLibcBridge_longjmp: 0x2D81C8C8
       SceLibstdcxx:
         kernel: false
         nid: 0xF7629240

--- a/loader/libc_bridge.h
+++ b/loader/libc_bridge.h
@@ -33,4 +33,10 @@ size_t sceLibcBridge_fwrite(const void *ptr, size_t size, size_t count, FILE *st
 int sceLibcBridge_ferror(FILE *stream);
 int sceLibcBridge_feof(FILE *stream);
 
+int sceLibcBridge_fprintf( FILE * stream, const char * format, ... );
+int sceLibcBridge_fputc(int ch, FILE *stream);
+
+int sceLibcBridge_setjmp(jmp_buf env);
+void sceLibcBridge_longjmp(jmp_buf env, int val);
+
 #endif

--- a/loader/main.c
+++ b/loader/main.c
@@ -893,8 +893,8 @@ static DynLibFunction dynlib_functions[] = {
   // { "fgetc", (uintptr_t)&fgetc },
   // { "fgets", (uintptr_t)&fgets },
   { "fopen", (uintptr_t)&sceLibcBridge_fopen },
-  // { "fprintf", (uintptr_t)&fprintf },
-  // { "fputc", (uintptr_t)&fputc },
+  { "fprintf", (uintptr_t)&fprintf },
+  { "fputc", (uintptr_t)&fputc },
   // { "fputs", (uintptr_t)&fputs },
   // { "fputwc", (uintptr_t)&fputwc },
   { "fread", (uintptr_t)&sceLibcBridge_fread },
@@ -977,8 +977,8 @@ static DynLibFunction dynlib_functions[] = {
   { "glVertexAttribPointer", (uintptr_t)&glVertexAttribPointer },
   { "glViewport", (uintptr_t)&glViewport },
 
-  // { "longjmp", (uintptr_t)&longjmp },
-  // { "setjmp", (uintptr_t)&setjmp },
+  { "longjmp", (uintptr_t)&longjmp },
+  { "setjmp", (uintptr_t)&setjmp },
 
   { "memchr", (uintptr_t)&sceClibMemchr },
   { "memcmp", (uintptr_t)&sceClibMemcmp },


### PR DESCRIPTION
Unlike the rest, Russian and Japanese languages load their fonts from respective .png files (`Menu_ApplyLanguage` function). A few calls down the line lead to a `setjmp` call at `0x1EDC0B` which causes a prefetch abort exception. After resolving that, turned out libpng `fprintf`s some kind of warning (at `0x1F25CE`), which caused another crash. IDK what that warning is so I just resolved what it needs.