### PR TITLE
Check libshacccg.suprx

### DIFF
--- a/loader/main.c
+++ b/loader/main.c
@@ -1208,7 +1208,7 @@ int main(int argc, char *argv[]) {
   if (check_kubridge() < 0)
     fatal_error("Error kubridge.skprx is not installed.");
 
-  if (!file_exists("ur0:/data/libshacccg.suprx"))
+  if (!file_exists("ur0:/data/libshacccg.suprx") && !file_exists("ur0:/data/external/libshacccg.suprx"))
     fatal_error("Error libshacccg.suprx is not installed.");
 
   if (so_load(SO_PATH) < 0)


### PR DESCRIPTION
In some cases the libshacccg.suprx located in the `ux0:data/external`.

here is the code in the [vitagl](https://github.com/Rinnegatamante/vitaGL/blob/ba29afd2161f4721a77797cb1289e8c678038154/source/gxm.c#L228)

```c
if (!is_shark_online)
   is_shark_online = shark_init("ur0:data/external/libshacccg.suprx") >= 0;
```