### PR TITLE
Fix for CJ's classic shadow, based on https://github.com/AndroidModLo…

### DIFF
--- a/loader/gfx_patch.c
+++ b/loader/gfx_patch.c
@@ -567,6 +567,15 @@ patch_gfx(void)
 		const uint32_t nop2 = 0xbf00bf00;
 		kuKernelCpuUnrestrictedMemcpy((void *)(gtasa_mod.text_base + 0x005A26B0), &nop2, sizeof(nop2));
 	}
+	
+	//Fix for CJ's shadow when using classic shadows
+	const uint16_t nop = 0xbf00;
+	uintptr_t destinationAddress = gtasa_mod.text_base + 0x5B86C4;
+
+	// Add 7 NOP instructions
+	for (int i = 0; i < 7; ++i) {
+		kuKernelCpuUnrestrictedMemcpy((void *)(destinationAddress + (i * sizeof(uint16_t))), &nop, sizeof(nop));
+	}
 }
 
 /*


### PR DESCRIPTION
Based on https://github.com/AndroidModLoader/JPatch/blob/main/preparations.inl with the following code:

// Classic CJ shadow if(cfg->GetBool("FixClassicCJShadow", true, "Gameplay")) 
{     
    aml->PlaceNOP(pGTASA + 0x5B86C4, 7); 
}

CJ's shadow is now showing the correct classic shadow when that option is chosen, and advanced shadows are still working as they did before.

Hope it's alright the way I have done it, with a for loop to add the 7 NOPs.